### PR TITLE
fixed threading

### DIFF
--- a/src/multimodaltranslation/audio/translate.py
+++ b/src/multimodaltranslation/audio/translate.py
@@ -11,6 +11,8 @@ from vosk import KaldiRecognizer, Model, SetLogLevel
 from multimodaltranslation.audio.install_models import install_model
 from multimodaltranslation.text.translate import translate_text
 
+import time
+
 SetLogLevel(-1)
 
 
@@ -169,3 +171,24 @@ def translate_audio(audio_bytes:bytes, lang:str, targets:list) -> list:
 
     translated_text = translate_text(text, lang, targets)
     return translated_text
+
+
+if __name__ == "__main__":
+    t1 = time.perf_counter()
+    lang = "en"
+    targets = ["it","fr", "ar", "en"]
+    script_dir = Path(__file__).resolve()
+    AUDIO_PATH = str(script_dir.parent.parent.parent.parent)
+    AUDIO_PATH = os.path.join(AUDIO_PATH,"audio_files","sample1","english.wav")
+
+    with open(AUDIO_PATH, "rb") as f:
+        AUDIO_BYTES = f.read()
+
+    results = translate_audio(  AUDIO_BYTES, lang=lang, targets=targets)
+
+    for result in results:
+        print(result)
+
+    t2 = time.perf_counter()
+    delta = str(t2-t1)
+    print(f"The program took {delta} seconds.")

--- a/src/multimodaltranslation/text/translate.py
+++ b/src/multimodaltranslation/text/translate.py
@@ -34,9 +34,6 @@ def translate_text(text:str, lang:str, targets:list[str]) -> list[dict[str,str]]
             future_result = executor.submit(_do_translate,text, lang, target) # see https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor
             responses.append(future_result) # building the future list
         data = concurrent.futures.as_completed(responses)
-        for d in data:
-            print(d.running())
-            print(d.done())
             
         results:list[dict[str,str]] = []
         #for d in data:
@@ -45,9 +42,7 @@ def translate_text(text:str, lang:str, targets:list[str]) -> list[dict[str,str]]
         # we loop through the futures and check the one which is complete to take it 
         # if you put a break point at the "for" loop you can see how 
         # it tries to find the completed future to get it from the iterator (responses)
-        for _ in concurrent.futures.as_completed(data):
-            print(f' is the future done {_.done()}')
-            print(f' is the future is still running {_.running()}')
+        for _ in concurrent.futures.as_completed(responses):
             results.append(_.result()) # obtain the result from the future
 
         t2 = time.perf_counter()
@@ -70,9 +65,15 @@ def _do_translate(text:str, lang:str, target:str)->dict[str,str]:
 
 
 if __name__ == "__main__":
+    
+    t1 = time.perf_counter()
     lang = "en"
-    targets = ["dk","se", "ar", "ku"]
+    targets = ["it", "fr", "en", "ar"]
     text = "Hi there"
     results = translate_text(text=text, lang=lang, targets=targets)
     for result in results:
         print(f"{result['text']}  {result['lang']}")
+    
+    t2 = time.perf_counter()
+    delta = str(t2-t1)
+    print(f"The program took {delta} seconds.")

--- a/src/multimodaltranslation/text/translate.py
+++ b/src/multimodaltranslation/text/translate.py
@@ -33,7 +33,6 @@ def translate_text(text:str, lang:str, targets:list[str]) -> list[dict[str,str]]
             # it will return a future which the worker thread will execute (future job to be executed in a seperate thread)
             future_result = executor.submit(_do_translate,text, lang, target) # see https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor
             responses.append(future_result) # building the future list
-        data = concurrent.futures.as_completed(responses)
             
         results:list[dict[str,str]] = []
         #for d in data:


### PR DESCRIPTION
**part 1:**

problem 1:
After you gave me the workshop to explain the code i guess you changed it without realising that you broke the program. 

before:
        data = concurrent.futures.as_completed(responses)
        for d in data:
            print(d.running())
            print(d.done())

data is just a one-shot iterator once we use it. It becomes empty after that. so the program was returning empty lists always. data becomes exhausted.

probem 2:
for _ in concurrent.futures.as_completed(data):
            results.append(_.result()) # obtain the result from the future

even if you don't use data. here the as_completed is expecting list of futures and not completed work. so instead we give the responses list to it.

for _ in concurrent.futures.as_completed(responses):
            results.append(_.result()) # obtain the result from the future

like this. 

**part 2:**

Regarding the threading for audio to text:

def translate_audio(audio_bytes:bytes, lang:str, targets:list) -> list:
    try:
        model_path = get_model(lang)
    except Exception as e:
        return [{"Error": str(e)}]

    try:
        text = audio_to_text(audio_bytes, model_path)
    except RuntimeError as e:
        return [{"Error":str(e)}]

    translated_text = translate_text(text, lang, targets)
    return translated_text

As you can see we get the model first (one time) and then transcribe the audio to text(using the model that we have to wait) and then we translate the transcribed text to the targets. But that is automatically done in threading mode because we are using the one we created. so it was integrated automatically. 
